### PR TITLE
chore: add ignore deps for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,4 @@
 {
-  "extends": ["config:base"]
+  "extends": ["config:base"],
+  "ignoreDeps": ["node.js", "next-mdx-remote", "remark-gfm"]
 }


### PR DESCRIPTION
## Description

- Add `ignoredeps` option for renovate
- https://docs.renovatebot.com/configuration-options/#ignoredeps

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
